### PR TITLE
Replaced proceedings information

### DIFF
--- a/bibliography.bib
+++ b/bibliography.bib
@@ -298,10 +298,10 @@
     annote       = {},
 }
 
-@InProceedings {Bro1992fecai,
+@InProceedings {Bro1992ecal,
     title        = {Artificial life and real robots},
     author       = Brooks_RA,
-    booktitle    = fecai_1992,
+    booktitle    = ecal_1992,
     editor       = Varela_FJ # and # Bourgine_P,
     series       = {},
     volume       = {},
@@ -1015,10 +1015,10 @@
     annote       = {},
 }
 
-@InProceedings {PerNicOneBra2011evoapp,
+@InProceedings {PerNicOneBra2011evoapps,
     title        = {Evolving behaviour trees for the {Mario} {AI} competition using grammatical evolution},
     author       = Perez_D # and # Nicolau_M # and # ONeill_M # and # Brabazon_A,
-    booktitle    = evoapp_2011,
+    booktitle    = evoapps_2011,
     editor       = DiChio_C # and # Cagnoni_S # and # Cotta_C # and # Ebner_M # and # Ekart_A # and # EsparciaAlcazar_AI # and # Merelo_JJ # and # Neri_F # and # Preuss_M # and # Richter_H # and # Togelius_J # and # Yannakakis_GN,
     series       = srs_LNCS,
     volume       = {6624},
@@ -1066,10 +1066,10 @@
     annote       = {},
 }
 
-@InProceedings {DuaGomCos-etal2016evoapp,
+@InProceedings {DuaGomCos-etal2016evoapps,
     title        = {Hybrid control for a real swarm robotics system in an intruder detection task},
     author       = Duarte_M # and # Gomes_J # and # Costa_V # and # Oliveira_SM # and # Christensen_AL,
-    booktitle    = evoapp_2016,
+    booktitle    = evoapps_2016,
     editor       = Squillero_G # and # Burelli_P,
     series       = srs_LNCS,
     volume       = {9598},
@@ -1428,10 +1428,10 @@
     annote       = {},
 }
 
-@InProceedings {LimBauCol2010evoapp,
+@InProceedings {LimBauCol2010evoapps,
     title        = {Evolving behaviour trees for the commercial game {DEFCON}},
     author       = Lim_CU # and # Baumgarten_R # and # Colton_S,
-    booktitle    = evoapp_2010,
+    booktitle    = evoapps_2010,
     editor       = DiChio_C # and # Cagnoni_S # and # Cotta_C # and # Ebner_M # and # Ekart_A # and # EsparciaAlcazar_AI # and # Goh_CK # and # Merelo_JJ # and # Neri_F # and # Preuss_M # and # Togelius_J # and # Yannakakis_GN,
     series       = srs_LNCS,
     volume       = {6024},
@@ -4890,10 +4890,10 @@
     annote      = {},
 }
 
-@InProceedings {KucVanBir2021evoapp,
+@InProceedings {KucVanBir2021evoapps,
     title        = {Automatic modular design of behavior trees for robot swarms with communication capabilities},
     author       = Kuckling_J # and # VanPelt_V # and # Birattari_M,
-    booktitle    = evoapp_2021,
+    booktitle    = evoapps_2021,
     editor       = Castillo_PA # and # JimenezLaredo_JL,
     series       = srs_LNCS,
     volume       = {12694},
@@ -4907,7 +4907,7 @@
     annote       = {},
 }
 
-@Misc {KucVanBir2021evoapplications-supp,
+@Misc {KucVanBir2021evoapps-supp,
     title        = {Automatic modular design of behavior trees with communication capabilities: supplementary material},
     author       = Kuckling_J # and # VanPelt_V # and # Birattari_M,
     howpublished = {\url{http://iridia.ulb.ac.be/supp/IridiaSupp2020-011/}},

--- a/proceedings-short.bib
+++ b/proceedings-short.bib
@@ -22,12 +22,12 @@ Name of general chair, or two general chair if no editors are mentioned and othe
 @string{ aamas_2015     = "AAMAS 2015" }
 @string{ aamas_2017     = "AAMAS 2017" }
 @string{ aamas_2018     = "AAMAS 2018" }
-@string{ ahs_2008       = "2008 NASA/ESA Conference on Adaptive Hardware and Systems" }
+@string{ ahs_2008       = "AHS 2008" }
 @string{ aiaa_2012      = "AIAA 2012" }
 @string{ aiide_2011     = "AIIDE 2011" }
-@string{ alife_1994     = "Artificial Life IV: Proceedings of the Workshop on the Synthesis and Simulation of Living Systems" }
-@string{ alife_2004     = "Artificial Life IX: Proceedings of the Ninth International Conference on the Simulation and Synthesis of Living Systems" }
-@string{ alife_2006     = "Artificial Life X: Proceedings of the Tenth International Conference on the Simulation and Synthesis of Living Systems" }
+@string{ alife_1994     = "Artificial Life IV" }
+@string{ alife_2004     = "Artificial Life IX" }
+@string{ alife_2006     = "Artificial Life X" }
 @string{ alife_2012     = "ALIFE 2012" }
 @string{ alife_2014     = "ALIFE 2014" }
 @string{ ants_2004      = "ANTS 2004" }
@@ -38,35 +38,36 @@ Name of general chair, or two general chair if no editors are mentioned and othe
 @string{ ants_2016      = "ANTS 2016" }
 @string{ ants_2018      = "ANTS 2018" }
 @string{ ants_2020      = "ANTS 2020" }
-@string{ arl_2003       = "Proceedings of the 8th International Symposium on Artificial Life and Robotics" }
+@string{ aos_1984       = "Sixth International Conference on Analysis and Optimization of Systems" }
+@string{ arob_2003      = "AROB 2003" }
 @string{ arsc_2009      = "ROBOTICA 2009" }
-@string{ aos_1984       = "Analysis and Optimization of Systems: Proceedings of the Sixth International Conference on Analysis and Optimization of Systems Nice" }
 @string{ ase_2015       = "ASE 2015" }
 
 @string{ bnaic_2019     = "BNAIC/BENELEARN 2019" }
 
-@string{ cdc_1985       = "1985 24th IEEE Conference on Decision and Control" }
+@string{ cdc_1985       = "CDC 1985" }
 @string{ cec_1999       = "CEC99" }
 @string{ cec_2005       = "CEC 2005" }
 @string{ cec_2009       = "CEC 2009" }
 @string{ cec_2015       = "CEC 2015" }
 
-@string{ dars_2000      = "Distributed Autonomous Robotic Systems 4" }
-@string{ dars_2002      = "Distributed Autonomous Robotic Systems 5" }
-@string{ dars_2007      = "Distributed Autonomous Robotic Systems 6" }
-@string{ dars_2013      = "Distributed Autonomous Robotic Systems: The 10th International Symposium" }
-@string{ dars_2018      = "Distributed Autonomous Robotic Systems: The 13th International Symposium" }
+@string{ dars_2000      = "DARS 4" }
+@string{ dars_2002      = "DARS 5" }
+@string{ dars_2007      = "DARS 6" }
+@string{ dars_2013      = "DARS 10" }
+@string{ dars_2018      = "DARS 13" }
 @string{ doceis_2011    = "DoCEIS 2011" }
 
 @string{ ea_2004        = "EA 2003" }
-@string{ ecal_1995      = "Advances in Artificial Life: Third European Conference on Artificial Life" }
+@string{ ecal_1992      = "First European Conference on Artificial Life" }
+@string{ ecal_1995      = "ECAL '95" }
 @string{ ecal_2001      = "ECAL 2001" }
 @string{ ecal_2003      = "ECAL 2003" }
 @string{ ecal_2003      = "ECAL 2017" }
-@string{ evoapp_2010    = "EvoApplications 2010" }
-@string{ evoapp_2011    = "EvoApplications 2011" }
-@string{ evoapp_2016    = "EvoApplications 2016" }
-@string{ evoapp_2021    = "EvoApplications 2020" }
+@string{ evoapps_2010   = "EvoApplications 2010" }
+@string{ evoapps_2011   = "EvoApplications 2011" }
+@string{ evoapps_2016   = "EvoApplications 2016" }
+@string{ evoapps_202    = "EvoApplications 2020" }
 
 @string{ hm_2007        = "HM 2007" }
 
@@ -76,9 +77,9 @@ Name of general chair, or two general chair if no editors are mentioned and othe
 @string{ icar_2017      = "ICAR 2017" }
 @string{ icarcv_2012    = "ICARCV 2012" }
 @string{ iccad_1995     = "ICCAD 1995" }
-@string{ iciis_1999     = "1999 International Conference on Information Intelligence and Systems" }
+@string{ iciis_1999     = "ICIIS'99" }
 @string{ iciis_2011     = "ICIIS 2011" }
-@string{ icinco_2011    = "Informatics in Control Automation and Robotics: Revised and Selected Papers from the International Conference on Informatics in Control Automation and Robotics 2009" }
+@string{ icinco_2011    = "ICINCO 2009" }
 @string{ icra_2000      = "ICRA 2000" }
 @string{ icra_2005      = "ICRA 2005" }
 @string{ icra_2009      = "ICRA 2009" }
@@ -97,8 +98,6 @@ Name of general chair, or two general chair if no editors are mentioned and othe
 @string{ iros_2007      = "IROS 2007" }
 @string{ iros_2012      = "IROS 2012" }
 @string{ iros_2018      = "IROS 2018" }
-
-@string{ fecai_1992     = "Towards a Practice of Autonomous Systems: Proceedings of the First European Conference on Artificial Life" }
 
 @string{ gdc_2005       = "GDC 2005" }
 @string{ gecco_2000     = "GECCO 2000" }
@@ -121,23 +120,16 @@ Name of general chair, or two general chair if no editors are mentioned and othe
 @string{ roman_2012     = "Ro-Man 2012" }
 @string{ rose_2018      = "RoSE 2018" }
 
-@string{ sab_1996       = "From Animals to Animats 4: Proceedings of the Fourth International Conference on Simulation of Adaptive Behavior" }
-@string{ sab_2004       = "From Animals to Animats 8: Proceedings of the Eighth International Conference on the Simulation of Adaptive Behavior" }
+@string{ sab_1996       = "From Animals to Animats 4" }
+@string{ sab_2004       = "From Animals to Animats 8" }
 @string{ sab_2005       = "SAB 2004" }
 @string{ sab_2006       = "SAB 2006" }
 @string{ sab_2012       = "SAB 2012" }
 @string{ sice_2014      = "SICE 2014" }
 @string{ siggraph_1994  = "SIGGRAPH 1994" }
 @string{ sis_2005       = "SIS 2005" }
-@string{ smcals_2006    = "2006 IEEE Mountain Workshop on Adaptive and Learning Systems" }
+@string{ smcals_2006    = "SMCals 2006" }
 @string{ ssci_2015      = "SSCI 2015" }
 
 @string{ taros_2018     = "TAROS 2018" }
 @string{ taros_2019     = "TAROS 2019" }
-
-
-
-
-
-
-

--- a/proceedings.bib
+++ b/proceedings.bib
@@ -25,7 +25,7 @@ Name of general chair, or two general chair if no editors are mentioned and othe
 @string{ ahs_2008       = "2008 NASA/ESA Conference on Adaptive Hardware and Systems" }
 @string{ aiaa_2012      = "AIAA Guidance, Navigation, and Control Conference" }
 @string{ aiide_2011     = "AIIDE'11: Proceedings of the Seventh AAAI Conference on Artificial Intelligence and Interactive Digital Entertainment" }
-@string{ alife_1994     = "Artificial Life IV: Proceedings of the Workshop on the Synthesis and Simulation of Living Systems" }
+@string{ alife_1994     = "Artificial Life IV: Proceedings of the Fourth International Workshop on the Synthesis and Simulation of Living Systems" }
 @string{ alife_2004     = "Artificial Life IX: Proceedings of the Ninth International Conference on the Simulation and Synthesis of Living Systems" }
 @string{ alife_2006     = "Artificial Life X: Proceedings of the Tenth International Conference on the Simulation and Synthesis of Living Systems" }
 @string{ alife_2012     = "ALIFE 2012: The Thirteenth International Conference on the Synthesis and Simulation of Living Systems" }
@@ -38,7 +38,7 @@ Name of general chair, or two general chair if no editors are mentioned and othe
 @string{ ants_2016      = "Swarm Intelligence: 10th International Conference, ANTS 2016" }
 @string{ ants_2018      = "Swarm Intelligence: 11th International Conference, ANTS 2018" }
 @string{ ants_2020      = "Swarm Intelligence: 12th International Conference, ANTS 2020" }
-@string{ aos_1984       = "Analysis and Optimization of Systems: Proceedings of the Sixth International Conference on Analysis and Optimization of Systems Nice" }
+@string{ aos_1984       = "Analysis and Optimization of Systems: Proceedings of the Sixth International Conference on Analysis and Optimization of Systems" }
 @string{ arob_2003      = "Proceedings of the 8th International Symposium on Artificial Life and Robotics" }
 @string{ arsc_2009      = "ROBOTICA 2009: Proceedings of the 9th Conference on Autonomous Robot Systems and Competitions" }
 @string{ ase_2015       = "2015 30th IEEE/ACM International Conference on Automated Software Engineering" }
@@ -59,16 +59,15 @@ Name of general chair, or two general chair if no editors are mentioned and othe
 @string{ doceis_2011    = "Technological Innovation for Sustainability: Second IFIP WG 5.5/SOCOLNET Doctoral Conference on Computing, Electrical and Industrial Systems, DoCEIS 2011" }
 
 @string{ ea_2004        = "Artificial Evolution: 6th International Conference, Evolution Artificielle, EA 2003" }
+@string{ ecal_1992      = "Towards a Practice of Autonomous Systems: Proceedings of the First European Conference on Artificial Life" }
 @string{ ecal_1995      = "Advances in Artificial Life: Third European Conference on Artificial Life" }
 @string{ ecal_2001      = "Advances in Artificial Life: 6th European Conference, ECAL 2001" }
 @string{ ecal_2003      = "Advances in Artificial Life: 7th European Conference, ECAL 2003" }
 @string{ ecal_2017      = "ECAL 2017, the Fourteenth European Conference on Artificial Life " }
-@string{ evoapp_2010    = "Applications of Evolutionary Computation. EvoApplications 2010: EvoCOMPLEX, EvoGAMES, EvoIASP, EvoINTELLIGENCE, EvoNUM, and EvoSTOC" }
-@string{ evoapp_2011    = "Applications of Evolutionary Computation. EvoApplications 2011: EvoCOMPLEX, EvoGAMES, EvoIASP, EvoINTELLIGENCE, EvoNUM, and EvoSTOC" }
-@string{ evoapp_2016    = "Applications of Evolutionary Computation: 19th European Conference, EvoApplications 2016" }
-@string{ evoapp_2021    = "Applications of Evolutionary Computation: 24th International Conference, EvoApplications 2021" }
-
-@string{ fecai_1992     = "Towards a Practice of Autonomous Systems: Proceedings of the First European Conference on Artificial Life" }
+@string{ evoapps_2010   = "Applications of Evolutionary Computation. EvoApplications 2010: EvoCOMPLEX, EvoGAMES, EvoIASP, EvoINTELLIGENCE, EvoNUM, and EvoSTOC" }
+@string{ evoapps_2011   = "Applications of Evolutionary Computation. EvoApplications 2011: EvoCOMPLEX, EvoGAMES, EvoIASP, EvoINTELLIGENCE, EvoNUM, and EvoSTOC" }
+@string{ evoapps_2016   = "Applications of Evolutionary Computation: 19th European Conference, EvoApplications 2016" }
+@string{ evoapps_2021   = "Applications of Evolutionary Computation: 24th International Conference, EvoApplications 2021" }
 
 @string{ gdc_2005       = "Game Developers Conference, GDC 2005" }
 @string{ gecco_2000     = "Proceedings of the Genetic and Evolutionary Computation Conference (GECCO '00)" }


### PR DESCRIPTION
Hey! This is probably the largest migration. Thanks!

Added new entries to proceedings:
evoapp_2010
cec_1999
dars_2013
icra_2000
icra_2005
iciis_2011
taros_2019
dars_2000
nabic_2009
iros_2007
icra_2020
icra_2012
doceis_2018

Corrected bib entries according to info in DOI:
Sah2004sab 		           by Sah2005sab **
Ben2004sab 		           by Ben2005sab **
RotEceGau2004iwsr 	   by RotEceGau2005sab **
LocAydNav-etal2012dars   by LocAydNav-etal2013dars
NeuGoo2018IJCAI 	           by NeuGoo2019ijcai

** The workshop was held on 2004, but the proceedings were published in 2005

Changed keys in proceedings for consistency:
NolFloMigMon1994ssls 		       by NolFloMigMon1994alife
Bal2005iwsr 				       by Bal2005sab
PerNicOneBra2011evoapplications 	by PerNicOneBra2011evoapp
DuaGomCos-etal2016evoapplications 	by DuaGomCos-etal2016evoapp
LimBauCol2010aec 			by LimBauCol2010evoapp
MarNol2006ssls 				by MarNol2006alife
TriTucDor2004fama 			by TriTucDor2004sab
JakHusHar1995aal 			by JakHusHar1995ecal
BonLip2004ssls 				by BonLip2004alife
Mac2003aai 				        by Mac2003ecal
ClaMooWan-etal2012ssls 		by ClaMooWan-etal2012alife
HarBreSeb2009ieeecec 		by HarBreSeb2009cec

Changed keys in collections for consistency:
FloHusNol2008HR 	        by FloHusNol2008hr
GarBir2016WEEEE 	by GarBir2016weeee
Lip2005BIOM 		        by Lip2005biom
LouMarStu2003metah 	by LouMarStu2003hm
NikJac2010metah 	        by NikJac2010hm
SpeTriNol2014ecc 	        by SpeTriNol2014gsoi