### PR TITLE
Updated information about extended Cedrata paper

### DIFF
--- a/bibliography.bib
+++ b/bibliography.bib
@@ -5834,21 +5834,21 @@
     annote       = {},
 }
 
-@Article {KucVanBir2021SNCS,
+@Article {KucVanBir2022SNCS,
     title        = {{AutoMoDe}-{Cedrata}: automatic design of behavior trees for controlling a swarm of robots with communication capabilities},
     author       = Kuckling_J # and # VanPelt_V # and # Birattari_M,
     journal      = SNCS,
     series       = {},
-    volume       = {},
+    volume       = {3},
     number       = {},
-    year         = {2021},
-    pages        = {},
-    doi          = {},
-    note         = {Submitted},
+    year         = {2022},
+    pages        = {136},
+    doi          = {10.1007/s42979-021-00988-9},
+    note         = {},
     annote       = {},
 }
 
-@Misc {KucVanBir2021SNCS-supp,
+@Misc {KucVanBir2022SNCS-supp,
     title        = {{AutoMoDe}-{Cedrata}: automatic design of behavior trees for controlling a swarm of robots with communication capabilities: supplementary material},
     author       = Kuckling_J # and # VanPelt_V # and # Birattari_M,
     howpublished = {\url{http://iridia.ulb.ac.be/supp/IridiaSupp2021-004/}},


### PR DESCRIPTION
[KucVanBir2021SNCS]: updated information and changed key to KucVanBir2022SNCS to match year of publication
[KucVanBir2021SNCS-supp]: changed key to KucVanBir2022SNCS-supp to match publication key. Did not update the year since the supplementary material was published in 2021 (and appears like that on the website and in the URL).